### PR TITLE
Set the subject prefix via config, with default value

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -98,6 +98,7 @@ contact:
         debug_address: name@example.com # Email address used when debug mode is enabled
         debug_smtp: true
         subject: Your message was submitted
+        subject_prefix: '[Boltforms]'
         replyto_name: '{NAME}'                 # Email addresses and names can be either the
         replyto_email: '{EMAIL}'                 # name of a field below or valid text.
         to_name: 'WebsiteName'     

--- a/src/EventSubscriber/Mailer.php
+++ b/src/EventSubscriber/Mailer.php
@@ -102,7 +102,7 @@ class Mailer implements EventSubscriberInterface
     private function getSubject(): string
     {
         $subject = $this->notification->get('subject', 'Untitled email');
-        $subject = Str::ensureStartsWith($subject, '[Boltforms] ');
+        $subject = Str::ensureStartsWith($subject, $this->notification->get('subject_prefix', '[Boltforms] ') . ' ');
 
         if ($this->event->isSpam()) {
             $subject = Str::ensureStartsWith($subject, '[SPAM] ');


### PR DESCRIPTION
Make the prefix of the subject changeable via form config, respecting the current default value if nothing is set. 