### PR TITLE
Added examples for using the Twig namespace when overwriting templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ For example:
 
 ```yaml
 quotations:
+    templates:                      # Override the global Twig templates if you want
+    #        form: @theme/form.twig
+    #        email: @theme/email.twig
+    #        subject: @theme/subject.twig
+    #        files: @theme/file_browser.twig
     feedback:
         success: Quotation request is received. We'll be in touch soon.
         error: There are errors in the form, please fix before trying to resubmit

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,6 +31,8 @@ spam-action: mark-as-spam # Either 'block', 'none' or 'mark-as-spam'
 # e.g. You created your templates in the `extensions/boltforms/` directory
 # inside your theme, you would use similar to:
 #
+# You can replace twig namesapce @boltforms with @theme which will point to your active theme folder
+# The namespace is configured in config/packages/twig.yaml
 templates:
     form: '@boltforms/form.html.twig'
     email: '@boltforms/email.html.twig'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,7 +31,7 @@ spam-action: mark-as-spam # Either 'block', 'none' or 'mark-as-spam'
 # e.g. You created your templates in the `extensions/boltforms/` directory
 # inside your theme, you would use similar to:
 #
-# You can replace twig namesapce @boltforms with @theme which will point to your active theme folder
+# You can replace twig namespace @boltforms with @theme which will point to your active theme folder
 # The namespace is configured in config/packages/twig.yaml
 templates:
     form: '@boltforms/form.html.twig'


### PR DESCRIPTION
In order to use custom templates a user should now how to overwrite the default twig @bolt namespace.

@I-Valchev pointed me in the right direction for this. 

I've created another PR in bolt/project to include the `@theme` namespace by default inside `config/packages/twig.yaml`
Both PR's are related.