### PR TITLE
fix PHP7.4 error due to wrong config implementation in EmailFactory

### DIFF
--- a/src/EventSubscriber/Mailer.php
+++ b/src/EventSubscriber/Mailer.php
@@ -65,7 +65,7 @@ class Mailer implements EventSubscriberInterface
     {
         $meta = $this->event->getMeta();
 
-        $email = (new EmailFactory())->create($this->event->getFormConfig(), $this->event->getForm(), $meta);
+        $email = (new EmailFactory())->create($this->event->getFormConfig(), $this->event->getConfig(), $this->event->getForm(), $meta);
 
         if ($this->event->isSpam()) {
             $subject = Str::ensureStartsWith($email->getSubject(), '[SPAM] ');

--- a/src/Factory/EmailFactory.php
+++ b/src/Factory/EmailFactory.php
@@ -21,13 +21,19 @@ class EmailFactory
     /** @var Collection */
     private $notification;
 
-    public function create(Collection $config, Form $form, array $meta = []): TemplatedEmail
+    /**
+     * @param Collection $formConfig The config specific for the current form
+     * @param Collection $config     The global config defined config/extensions/bolt-boltforms.yaml
+     * @param Form       $form       The form object
+     * @param array      $meta       Metadata of the PostSubmitEvent
+     */
+    public function create(Collection $formConfig, Collection $config, Form $form, array $meta = []): TemplatedEmail
     {
         $this->config = $config;
-        $this->notification = collect($config->get('notification', []));
+        $this->notification = collect($formConfig->get('notification', []));
         $this->form = $form;
 
-        $debug = (bool) $config->get('debug')['enabled'];
+        $debug = (bool) $this->config->get('debug')['enabled'];
 
         $email = (new TemplatedEmail())
             ->from($this->getFrom())
@@ -38,7 +44,7 @@ class EmailFactory
                 'data' => $form->getData(),
                 'formname' => $form->getName(),
                 'meta' => $meta,
-                'config' => $config,
+                'config' => $formConfig,
             ]);
 
         if (self::hasCc()) {


### PR DESCRIPTION
Fixes #19

## What was the problem

Basically with PHP 7.4 after sending a form there has been an error that `Trying to access array offset on value of type null` appeared in `src/factory/EmailFactory.php` at Line 29

After some debugging I found out, that the given `$config` variable was not the collection of the whole `config/extensions/bolt-boltforms.yaml` but rather just the subset of the currently used form.

So like just this subset: (and ongoing till the fields of this form end)
![image](https://user-images.githubusercontent.com/9105243/96635412-1bb83080-131c-11eb-820e-ad3a0b441f97.png)

But the logic in `src/factory/EmailFactory.php` used config keys like `debug` and `address` which (partially) aren't present in this subset.

So therefore there was a mix between config for the form and the "whole" config for the extension.

## What I did

Basically I went into `src/EventSubscriber/Mailer.php` and added the `$this->event->getConfig()` as a parameter after the already present `$this->event->getFormConfig()`

After that adjusted the parameters for the `create()` function in `src/Factory/EmailFactory.php` to match the new parameters and fixed the mixed config variables.

So sometimes we want to access config just for the current form, but sometimes we want to access the config for the "global" extension.

This PR should fix this.

I `dd()` the variables which previously caused problems and they are now correct in my opinion.