### PR TITLE
Save the filename of an attachment to a text field

### DIFF
--- a/src/EventSubscriber/ContentTypePersister.php
+++ b/src/EventSubscriber/ContentTypePersister.php
@@ -12,6 +12,7 @@ use Bolt\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tightenco\Collect\Support\Collection;
 
 class ContentTypePersister extends AbstractPersistSubscriber implements EventSubscriberInterface
@@ -25,11 +26,15 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
     /** @var EntityManagerInterface */
     private $em;
 
-    public function __construct(Config $boltConfig, UserRepository $userRepository, EntityManagerInterface $em)
+    /** @var string */
+    private $projectDir;
+
+    public function __construct(Config $boltConfig, UserRepository $userRepository, EntityManagerInterface $em, string $projectDir = '')
     {
         $this->boltConfig = $boltConfig;
         $this->userRepository = $userRepository;
         $this->em = $em;
+        $this->projectDir = $projectDir;
     }
 
     public function save(PostSubmitEvent $event, Form $form, Collection $config): void
@@ -75,8 +80,20 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
 
         foreach ($data as $field => $value) {
             $name = $mapping->get($field, $field);
-
             if ($name !== null) {
+                if (in_array($name, array_keys($data['attachments'] ?? null))) {
+                    // Don't save the file. Rather, save the filename that's in attachments.
+                    $value = $data['attachments'][$name];
+
+                    // Don't save the full path. Only the path without the project dir.
+                    $newValue = [];
+                    foreach ($value as $i => $path) {
+                        $newValue[] = str_replace($this->projectDir, "", $path);
+                    }
+
+                    $value = $newValue;
+                }
+
                 $content->setFieldValue($name, $value);
             }
         }

--- a/src/EventSubscriber/FileUploadHandler.php
+++ b/src/EventSubscriber/FileUploadHandler.php
@@ -56,7 +56,7 @@ class FileUploadHandler implements EventSubscriberInterface
         $files = $this->uploadFiles($filename, $file, $path);
 
         if (isset($fieldConfig['attach']) && $fieldConfig['attach']) {
-            $event->addAttachments($files);
+            $event->addAttachments([$field->getName() => $files]);
         }
     }
 

--- a/src/Factory/EmailFactory.php
+++ b/src/Factory/EmailFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\BoltForms\Factory;
 
 use Bolt\Common\Str;
+use File;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Mime\Address;
@@ -66,9 +67,11 @@ class EmailFactory
             $email->replyTo($this->getReplyTo());
         }
 
-        /** @var File $attachment */
-        foreach ($attachments as $attachment) {
-            $email->attachFromPath($attachment);
+        foreach ($attachments as $name => $attachment) {
+            /** @var File $attachment */
+            foreach ($attachment as $file) {
+                $email->attachFromPath($file, $name . '.' . pathinfo($file, PATHINFO_EXTENSION));
+            }
         }
 
         // Override the "to"

--- a/templates/email_blocks.html.twig
+++ b/templates/email_blocks.html.twig
@@ -4,8 +4,6 @@
             {%- set field = attribute(config.fields, fieldname) %}
             {%- set label = field.options.label|default(fieldname) %}
 
-            {% dump(field.type) %}
-
             {% if not (field.type == 'file' and field.attach|default) %}
                 {%- if values is iterable %}
                     <li>


### PR DESCRIPTION
Fine for limited cases, but it won't work with multiple files for example.

On the + side, the names of files in attachments are nicer now (essentially the name of the field), rather than some very long random string.