### PR TITLE
Strip tags on labels in e-mail

### DIFF
--- a/templates/email_blocks.html.twig
+++ b/templates/email_blocks.html.twig
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block field_label %}
-    {%- if label is not empty %}{{ label }}: {% endif %}
+    {%- if label is not empty %}{{ label|striptags }}: {% endif %}
 {% endblock %}
 
 {% block field_value %}


### PR DESCRIPTION
If you're using `label_html` in your form definition, you probably still don't want the email to include the written-out HTML tags. 
