### PR TITLE
Emails in table format

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,7 +35,7 @@ spam-action: mark-as-spam # Either 'block', 'none' or 'mark-as-spam'
 # The namespace is configured in config/packages/twig.yaml
 templates:
     form: '@boltforms/form.html.twig'
-    email: '@boltforms/email.html.twig'
+    email: '@boltforms/email_table.html.twig' # Replace with @boltforms/email.html.twig to send simple list-based emails.
     subject: '@boltforms/subject.html.twig'
     files: '@boltforms/file_browser.twig'
 

--- a/templates/email_blocks_table.html.twig
+++ b/templates/email_blocks_table.html.twig
@@ -6,6 +6,11 @@
 
             {{ block('print_field') }}
         {%- endfor %}
+
+        {%- for label, value in meta %}
+            {% set label = label|capitalize %}
+            {{ block('print_field') }}
+        {%- endfor %}
     </table>
 
     <style>
@@ -37,7 +42,7 @@
 {% block print_label %}
     {% if block('label_'~label) is defined %}
         {{ block('label_'~label) }}
-    {% elseif block('label_'~definition.type) is defined %}
+    {% elseif block('label_'~definition.type|default) is defined %}
         {{ block('label_'~definition.type) }}
     {% else %}
         {{ block('label_generic') }}
@@ -62,7 +67,7 @@
 {% block print_value %}
     {% if block('value_'~label) is defined %}
         {{ block('value_'~label) }}
-    {% elseif block('value_'~definition.type) is defined %}
+    {% elseif block('value_'~definition.type|default) is defined %}
         {{ block('value_'~definition.type) }}
     {% else %}
         {{ block('value_generic') }}

--- a/templates/email_blocks_table.html.twig
+++ b/templates/email_blocks_table.html.twig
@@ -1,0 +1,99 @@
+{% block submission_summary %}
+    <table class="boltforms">
+        {%- for fieldname, value in data|filter((value, fieldname) => attribute(config.fields, fieldname) is defined) %}
+            {%- set definition = attribute(config.fields, fieldname) %}
+            {%- set label = definition.options.label|default(fieldname)|replace({'_':' '})|capitalize %}
+
+            {{ block('print_field') }}
+        {%- endfor %}
+    </table>
+
+    <style>
+        table.boltforms td{
+            padding: 3px 15px;
+            max-width: 40ch;
+        }
+    </style>
+{% endblock %}
+
+{# Print the label and value for a field. #}
+{% block print_field %}
+    <tr>
+        <td>
+            {{ block('print_label') }}
+        </td>
+        <td>
+            {{ block('print_value') }}
+        </td>
+    </tr>
+{% endblock %}
+
+{#  Print the label of a field.
+    One of three blocks is used, in order of priority:
+    1. A block based on the field label, e.g. label_first_name
+    2. A block based on the field type, e.g. label_text
+    3. Otherwise, use the label_generic block.
+#}
+{% block print_label %}
+    {% if block('label_'~label) is defined %}
+        {{ block('label_'~label) }}
+    {% elseif block('label_'~definition.type) is defined %}
+        {{ block('label_'~definition.type) }}
+    {% else %}
+        {{ block('label_generic') }}
+    {% endif %}
+{% endblock %}
+
+{# Use {{ label }} variable. #}
+{% block label_generic %}
+    {{ label }}
+{% endblock %}
+
+{# Don't show any file field labels.#}
+{% block label_file %}
+{% endblock %}
+
+{#  Print the value of a field. #}
+{#  Available variables: value, definition, label. #}
+{#  One of three blocks is used, in order of priority#}
+{#  1. A block based on the field label, e.g. value_first_name#}
+{#  2. A block based on the field type, e.g. value_text#}
+{#  3. Otherwise, use the value_generic block.#}
+{% block print_value %}
+    {% if block('value_'~label) is defined %}
+        {{ block('value_'~label) }}
+    {% elseif block('value_'~definition.type) is defined %}
+        {{ block('value_'~definition.type) }}
+    {% else %}
+        {{ block('value_generic') }}
+    {% endif %}
+{% endblock %}
+
+{# Use the {{ value }} variable. #}
+{% block value_generic %}
+    {% if value is iterable %}
+        <ul>
+            {% for v in value %}
+                <li>{{ v }}</li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        {{ value }}
+    {% endif %}
+{% endblock %}
+
+{% block value_date %}
+    {{ value|localdate }}
+{% endblock %}
+
+{% block value_datetime %}
+    {{ value|localdate }}
+{% endblock %}
+
+{% block value_dateinterval %}
+    {{ value|localdate }}
+{% endblock %}
+
+{# Don't show any file fields. #}
+{% block value_file %}
+{% endblock %}

--- a/templates/email_table.html.twig
+++ b/templates/email_table.html.twig
@@ -1,0 +1,21 @@
+{#
+# Passed in variables:
+#   email    — The mail's WrappedTemplatedEmail instance
+#   data     — POSTed data
+#   formname — Field data from the form configuration
+#   config   — Current Form's configuration data
+#   meta     — Meta data (IP, URL, Timestamp)
+#}
+<p>Dear <strong>{{ email.toName }}</strong>, </p>
+
+<p>Somebody used the form <strong>{{ formname }}</strong> on {{ meta.url }} to send you a message.</p>
+
+<p>The posted data is as follows:</p>
+
+<hr size="1">
+{{ block('submission_summary', '@boltforms/email_blocks_table.html.twig') }}
+<hr size="1">
+
+<br>
+
+<em>Sent by the <a href="https://github.com/bolt/boltforms">BoltForms</a> extension for <a href="https://boltcms.io">Bolt</a>.</em>


### PR DESCRIPTION
For new installations, use the `email_table.html.twig` by default.
For existing ones, keep the `email.html.twig` with the `ul`-based formatting.