### PR TITLE
Allow mapping for fields in ContentType that aren't in the Form definition

### DIFF
--- a/src/EventSubscriber/ContentTypePersister.php
+++ b/src/EventSubscriber/ContentTypePersister.php
@@ -12,7 +12,6 @@ use Bolt\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Form;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Tightenco\Collect\Support\Collection;
 
 class ContentTypePersister extends AbstractPersistSubscriber implements EventSubscriberInterface
@@ -82,14 +81,14 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
         foreach ($data as $field => $value) {
             $name = $mapping->get($field, $field);
             if ($name !== null) {
-                if (in_array($name, array_keys($data['attachments'] ?? null))) {
+                if (in_array($name, array_keys($data['attachments'] ?? null), true)) {
                     // Don't save the file. Rather, save the filename that's in attachments.
                     $value = $data['attachments'][$name];
 
                     // Don't save the full path. Only the path without the project dir.
                     $newValue = [];
                     foreach ($value as $i => $path) {
-                        $newValue[] = str_replace($this->projectDir, "", $path);
+                        $newValue[] = str_replace($this->projectDir, '', $path);
                     }
 
                     $value = $newValue;

--- a/src/EventSubscriber/ContentTypePersister.php
+++ b/src/EventSubscriber/ContentTypePersister.php
@@ -78,6 +78,7 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
             $form->getData()
         );
 
+        // Map given data to fields, using the mapping
         foreach ($data as $field => $value) {
             $name = $mapping->get($field, $field);
             if ($name !== null) {
@@ -95,6 +96,13 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
                 }
 
                 $content->setFieldValue($name, $value);
+            }
+        }
+
+        // And the reverse: Map the mapping to fields from the data
+        foreach ($mapping as $mappingName => $fieldName) {
+            if ($content->hasFieldDefined($mappingName) && array_key_exists($fieldName, $data)) {
+                $content->setFieldValue($mappingName, $data[$fieldName]);
             }
         }
     }


### PR DESCRIPTION
For example, you can do this: 

```yaml
    database:
        contenttype:
            name: foo
            field_map:
                timestamp: ~
                url: ~
                attachments: ~
                slug: title
```

Doing this, in the contentType, the `slug` field will be set to a (sluggified) `title` from the Form. 