### PR TITLE
Add `ignore_missing` option

### DIFF
--- a/docs/handlers/save_to_contenttype.md
+++ b/docs/handlers/save_to_contenttype.md
@@ -1,12 +1,9 @@
 Create a form and save it to a ContentType
 ==========================================
 
-Scroll down to `contact:` where you'll find the configuration for the default
-contact form.
-
-To create a new form and store submissions in a Bolt ContentType, add a new key
-to the yaml file, along with the options for the new form. For example, create 
-a file `quotation.yaml` in the folder `config/extensions/bolt-boltforms`:
+To create a new form and store submissions in a Bolt ContentType, first 
+create a new form. For example, create a file `quotation.yaml` in the folder 
+`config/extensions/bolt-boltforms`:
 
 ```yaml
 # config/extensions/bolt-boltforms/quotation.yaml

--- a/docs/handlers/save_to_contenttype.md
+++ b/docs/handlers/save_to_contenttype.md
@@ -5,61 +5,103 @@ Scroll down to `contact:` where you'll find the configuration for the default
 contact form.
 
 To create a new form and store submissions in a Bolt ContentType, add a new key
-to the yaml file, along with the options for the new form. For example:
+to the yaml file, along with the options for the new form. For example, create 
+a file `quotation.yaml` in the folder `config/extensions/bolt-boltforms`:
 
 ```yaml
-quotations:
-    templates:                      # Override the global Twig templates if you want
-    #        form: @theme/form.twig
-    #        email: @theme/email.twig
-    #        subject: @theme/subject.twig
-    #        files: @theme/file_browser.twig
-    feedback:
-        success: Quotation request is received. We'll be in touch soon.
-        error: There are errors in the form, please fix before trying to resubmit
-    database:
-        contenttype:
-            name: quotations # save all form submissions to the quotations contenttype
-            field_map:
-                timestamp: ~ # do not save the timestamp
-                url: ~ # do not save the url
-                path: ~ # do not save the path
-                ip: ~ # do not save the ip
-    fields:
-        name:
-            type: text
-            options:
-                required: true
-                label: Name
-                attr:
-                    placeholder: Your name...
-                constraints: [ NotBlank, { Length: { 'min': 3, 'max': 128 } } ]
-        email:
-            type: email
-            options:
-                required: true
-                label: Email address
-                attr:
-                    placeholder: Your email...
-                constraints: [ NotBlank, Email ]
-        needhelp:
-            type: choice
-            options:
-                required: true
-                label: What project do you need help with?
-                choices: { 'Web development': 'web-development', 'Mobile development': 'mobile-development', 'Marketing': 'marketing' }
-        details:
-            type: textarea
-            options:
-                required: true
-                label: Please descript your desired app
-        submit:
-            type: submit
-            options:
-                label: Request quotation »
-                attr:
-                    class: button primary
+# config/extensions/bolt-boltforms/quotation.yaml
+
+templates:  # Override the global Twig templates if you want
+templates:                      # Override the global Twig templates if you want
+#        form: @theme/form.twig
+#        email: @theme/email.twig
+#        subject: @theme/subject.twig
+#        files: @theme/file_browser.twig
+feedback:
+  success: Quotation request has been received. We'll be in touch soon.
+  error: There are errors in the form. Please fix them, before trying to resubmit
+database:
+  contenttype:
+    name: quotations # save all form submissions to the quotations contenttype
+    ignore_missing: true # ignore fields in the form that aren't defined in the ContentType
+fields:
+  name:
+    type: text
+    options:
+      required: true
+      label: Name
+      attr:
+        placeholder: Your name...
+      constraints: [ NotBlank, { Length: { 'min': 3, 'max': 128 } } ]
+  email:
+    type: email
+    options:
+      required: true
+      label: Email address
+      attr:
+        placeholder: Your email...
+      constraints: [ NotBlank, Email ]
+  needhelp:
+    type: choice
+    options:
+      required: true
+      label: What project do you need help with?
+      choices: { 'Web development': 'web-development', 'Mobile development': 'mobile-development', 'Marketing': 'marketing' }
+  details:
+    type: textarea
+    options:
+      required: true
+      label: Description
+      attr:
+        placeholder: Please describe your desired website or app…
+  submit:
+    type: submit
+    options:
+      label: Request quotation »
+      attr:
+        class: button primary
 ```
+
+To store the data, you'd need a ContentType `quotations`, as referenced in the 
+form above. For example: 
+
+```yaml
+# config/bolt/contenttypes.yaml
+
+quotations:
+  name: Quotations
+  singular_name: Quotation
+  title_format: "Quotation request from: {name}"
+  fields:
+    name:
+      type: text
+      variant: inline
+    email:
+      type: text
+      variant: inline
+    needhelp:
+      type: text
+      variant: inline
+    details:
+      type: textarea
+    timestamp:
+      type: text
+      variant: inline
+    url:
+      type: text
+      variant: inline
+    path:
+      type: text
+      variant: inline
+    ip:
+      type: text
+      variant: inline
+```
+
+As a result, the submissions of the form will be stored as proper Records in 
+your Bolt backend. See this screenshot as an example: 
+
+![Form saved as Bolt Record](https://user-images.githubusercontent.com/1833361/122095553-d34f0500-ce0d-11eb-827d-00077c00c53f.png)
 
 If the name of the fields in your ContentType and the form do not match exactly,
 use the `field_map` option to override the default mapping:
@@ -67,9 +109,9 @@ use the `field_map` option to override the default mapping:
 ```yaml
     database:
         contenttype:
-            name: quotations # save all form submissions to the quotations contenttype
+            name: quotations # save all form submissions to the quotations ContentType
             field_map:
-                name: customer_name # name is the form field. customer_name is the contenttype field.
+                name: customer_name # name is the form field. customer_name is the ContentType field.
 ```
 
 In addition to all form fields, you can also keep the following information:
@@ -80,6 +122,21 @@ In addition to all form fields, you can also keep the following information:
 * `ip` - the ip address of the user submitting the form
 * `attachments` - an array of attached files from file fields
 
-To store that information in a ContentType, simply create a field for each option that
-you want to keep, and remove the override from the form config, e.g.
+To store that information in a ContentType, simply create a field for each 
+option that you want to keep, and remove the override from the form config:
+
 `ip: ~ # do not save the ip <- REMOVE THIS LINE`
+
+By default, Boltforms silently ignores fields from the form that are missing from the ContentType. Often this is what you want, because you might not need an `attachments` field, if the form has no file uploads. However, if you do want to have this strict behaviour, set `ignore_missing: false`, like so: 
+
+```yaml
+    database:
+        contenttype:
+            name: quotations # save all form submissions to the quotations ContentType
+            field_map:
+              timestamp: ~ # do not save the timestamp
+              url: ~ # do not save the url
+              path: ~ # do not save the path
+              ip: ~ # do not save the ip
+            ignore_missing: false
+```

--- a/src/EventSubscriber/ContentTypePersister.php
+++ b/src/EventSubscriber/ContentTypePersister.php
@@ -80,20 +80,31 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
         // Map given data to fields, using the mapping
         foreach ($data as $field => $value) {
             $name = $mapping->get($field, $field);
-            if ($name !== null) {
-                if (in_array($name, array_keys($data['attachments'] ?? null), true)) {
-                    // Don't save the file. Rather, save the filename that's in attachments.
-                    $value = $data['attachments'][$name];
 
-                    // Don't save the full path. Only the path without the project dir.
-                    $newValue = [];
-                    foreach ($value as $path) {
-                        $newValue[] = str_replace($this->projectDir, '', $path);
-                    }
+            if ($name === null) {
+                continue;
+            }
 
-                    $value = $newValue;
+            if (is_array($value)) {
+                $value = implode(", ", $value);
+            }
+            $value = (string) $value;
+
+            if (in_array($name, array_keys($data['attachments'] ?? null), true)) {
+                // Don't save the file. Rather, save the filename that's in attachments.
+                $value = $data['attachments'][$name];
+
+                // Don't save the full path. Only the path without the project dir.
+                $newValue = [];
+                foreach ($value as $i => $path) {
+                    $newValue[] = str_replace($this->projectDir, '', $path);
                 }
 
+                $value = $newValue;
+            }
+
+
+            if ($content->hasFieldDefined($name) || !($config['ignore_missing'] ?? false)) {
                 $content->setFieldValue($name, $value);
             }
         }


### PR DESCRIPTION
This adds the `ignore_missing` option, to make inserting submitted Forms into Bolt Records a lot less fickle. 

Consequently fixes #67 
Also fixes #35