### PR TITLE
Fix Event Priority, ensure marking mail as `[SPAM]`

### DIFF
--- a/src/EventSubscriber/HoneypotSubscriber.php
+++ b/src/EventSubscriber/HoneypotSubscriber.php
@@ -50,7 +50,7 @@ class HoneypotSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            'boltforms.post_submit' => ['handleEvent', 20],
+            'boltforms.post_submit' => ['handleEvent', 50],
         ];
     }
 }

--- a/src/EventSubscriber/Mailer.php
+++ b/src/EventSubscriber/Mailer.php
@@ -79,7 +79,7 @@ class Mailer implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            'boltforms.post_submit' => ['handleEvent', 40],
+            'boltforms.post_submit' => ['handleEvent', 30],
         ];
     }
 }


### PR DESCRIPTION
Protip: Mark as spam _first_ and _then_ send out the emails! 

Fixes #71