### PR TITLE
Add form `id` attribute

### DIFF
--- a/templates/form.html.twig
+++ b/templates/form.html.twig
@@ -42,5 +42,5 @@
 
 {% if not valid %}
     {% include '@boltforms/honeypotstyle.html.twig' with {'honeypot_name': honeypot_name} %}
-    {{ form(form) }}
+    {{ form(form, {'attr': { 'id': form.vars.id|default }}) }}
 {% endif %}


### PR DESCRIPTION
This makes it possible to target the form, e.g. include fields that are outside of the `form` tag.