### PR TITLE
Fix that PostSubmitEvent is not called as a service in an autowire

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,3 +5,6 @@ services:
   Bolt\BoltForms\EventSubscriber\FileUploadHandler:
     arguments:
       $projectDir: '%kernel.project_dir%'
+  Bolt\BoltForms\Event\PostSubmitEvent:
+    autowire: false
+    autoconfigure: false


### PR DESCRIPTION
If you use the __construct function to autowire the PostSubmitEvent it throws an error saying its not a service. This fixes that error.