### PR TITLE
Fix `The option "constraints" with value null is expected to be of type "Symfony\Component\Validator\Constraint"`

### DIFF
--- a/src/Factory/FieldConstraints.php
+++ b/src/Factory/FieldConstraints.php
@@ -10,10 +10,10 @@ class FieldConstraints
 {
     public const SF_NAMESPACE = '\\Symfony\\Component\\Validator\\Constraints\\';
 
-    public static function get(string $formName, array $field): ?array
+    public static function get(string $formName, array $field): array
     {
         if (! \array_key_exists('constraints', $field)) {
-            return null;
+            return [];
         }
 
         $result = [];


### PR DESCRIPTION
I'm not sure why this only shows up now... 🤔

![image](https://user-images.githubusercontent.com/7093518/146906835-7bac1701-235b-4ff3-9388-b65058365363.png)

