### PR TITLE
fix #92

### DIFF
--- a/src/EventSubscriber/ContentTypePersister.php
+++ b/src/EventSubscriber/ContentTypePersister.php
@@ -86,7 +86,9 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
             }
 
             if (is_array($value)) {
-                $value = implode(', ', $value);
+                $value = implode(', ', array_map(function ($entry) {
+                  return $entry[0];
+                }, $value));
             }
             $value = (string) $value;
 


### PR DESCRIPTION
the absolute upload path will be stored when attach is true
 ```
     picture:
        type: file
        attach: true  # <--- attach: true must be set.
```



Signed-off-by: David Krause <krause@biochem2.uni-frankfurt.de>