### PR TITLE
Add gregwar captcha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": ">=7.2.9",
         "twig/twig": "^2.12 || ^3.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "gregwar/captcha-bundle": "^2.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-symfony": "^0.12",
-        "bolt/core": "^4.1",
+        "bolt/core": "^5.1",
         "symplify/easy-coding-standard": "^10.2"
     },
     "autoload": {

--- a/docs/captcha.md
+++ b/docs/captcha.md
@@ -5,6 +5,7 @@ Bolt forms support the following CAPTCHA platforms:
 
 * [Google reCAPTCHA](https://www.google.com/recaptcha/about/) (v3, v2 checkbox, v2 invisible)
 * [hCaptcha](https://www.hcaptcha.com/)
+* [gregwarCaptcha](https://github.com/Gregwar/CaptchaBundle) (Captcha without 3rd party dependencies)
 
 You will need to obtain a site key and secret key from either of the above platforms.
 
@@ -74,6 +75,10 @@ contact:
             options:
                 captcha_type: recaptcha_v2
                 captcha_invisible: true
+
+        # Gregwar Captcha:
+        my_gregwar_captcha:
+            type: gregwarCaptcha
 
         # submit button must come after the CAPTCHA
 ```

--- a/src/Factory/FieldType.php
+++ b/src/Factory/FieldType.php
@@ -157,6 +157,9 @@ class FieldType
             case 'week':
                 $type = WeekType::class;
                 break;
+            case 'gregwarCaptcha':
+                $type = \Gregwar\CaptchaBundle\Type\CaptchaType::class;
+                break;
             default:
                 $type = TextType::class;
                 break;

--- a/src/Form/CaptchaType.php
+++ b/src/Form/CaptchaType.php
@@ -36,6 +36,6 @@ class CaptchaType extends HiddenType
 
     public function getBlockPrefix()
     {
-        return 'captcha';
+        return 'boltFormsCaptcha';
     }
 }

--- a/templates/captcha.html.twig
+++ b/templates/captcha.html.twig
@@ -1,10 +1,10 @@
-{% block captcha_label %}
+{% block boltFormsCaptcha_label %}
     {% if captcha_type != 'recaptcha_v3' and (captcha_type != 'recaptcha_v2' or not captcha_invisible) and label !== false %}
         {{ block('form_label') }}
     {% endif %}
 {% endblock %}
 
-{% block captcha_widget %}
+{% block boltFormsCaptcha_widget %}
     {% if captcha_type == 'hcaptcha' %}
         <div class="h-captcha" data-sitekey="{{ hcaptcha_public_key }}" data-theme="{{ hcaptcha_theme }}"></div>
     {% elseif captcha_type == 'recaptcha_v3' %}


### PR DESCRIPTION
This PR will add another captcha type, for that [Gregwar Captcha](https://github.com/Gregwar/Captcha) will be used.
To be exact this PR use the [symfony bundle](https://github.com/Gregwar/CaptchaBundle).

Because there is no longer a EU-US Privacy Shield, you are no longer allowed to use google services without opt in (which don't really make sense for captchas) of the user.
So this captcha has no 3rd party dependecies to build or validate the captcha.

Of course you can customize the whole formtype (see documentation of grewar [captcha bundle](https://github.com/Gregwar/CaptchaBundle#options))

![Bildschirm­foto 2022-11-10 um 11 27 11](https://user-images.githubusercontent.com/13292481/201066992-635736c5-1985-44ae-bc23-086a95c2b60d.png)
![Bildschirm­foto 2022-11-10 um 11 27 03](https://user-images.githubusercontent.com/13292481/201067000-8f4f3a9d-4467-49c2-b1fe-8a50664c159c.png)
