### PR TITLE
Add possibility to override default field config and document it

### DIFF
--- a/docs/overriding_form_configuration.md
+++ b/docs/overriding_form_configuration.md
@@ -1,0 +1,39 @@
+Overriding form configuration
+=========
+### Configuration overrides in the tag
+
+Configuration parameters can be overridden at runtime by passing them in using
+the `data` named parameter.
+
+#### Overriding the default value of a text field
+
+In this example the text field `field_name` will render with the value `default_field_value`.
+
+```twig
+    {{ boltforms('form_name',
+        data = {
+            'field_name': 'default_field_value'
+            }
+        })
+    }}
+```
+
+#### Overriding the default options of a field 
+
+In this example the `label` of the `field_name` field is being overridden and rendering with the value `new_label`. 
+
+```twig
+    {{ boltforms('contact_subsites',
+        data = {
+            'field_name': {
+                options: {
+                    label: 'new_label'
+                }
+            }
+        })
+    }}
+```
+
+**NOTE:** Where the override array key matches a field name, the field name is
+overridden, if it then matches a field configuration parameter, that will be
+the affected value.

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -43,7 +43,11 @@ class FormBuilder
         foreach ($config->get($formName)['fields'] as $name => $field) {
             // If we passed in a default value, set it as the Field's `data`-value
             if (array_key_exists($name, $data)) {
-                $field['options']['data'] = $data[$name];
+                if(is_iterable($data[$name])){
+                    $field['options'] = array_merge($field['options'], $data[$name]['options']);
+                } else {
+                    $field['options']['data'] = $data[$name];
+                }
             }
 
             if ($field['type'] === 'captcha') {


### PR DESCRIPTION
This PR allows to override configuration of a form field during runtime. It also adds documentation how to override the configuration.