### PR TITLE
Add ability to decide whether to cache the choices of type contenttype 

### DIFF
--- a/src/Form/ContenttypeType.php
+++ b/src/Form/ContenttypeType.php
@@ -14,14 +14,17 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Cache\CacheInterface;
 
 class ContenttypeType extends AbstractType
 {
     private $query;
+    private $cache;
 
-    public function __construct(Query $query)
+    public function __construct(Query $query, CacheInterface $cache)
     {
         $this->query = $query;
+        $this->cache = $cache;
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -43,7 +43,7 @@ class FormBuilder
         foreach ($config->get($formName)['fields'] as $name => $field) {
             // If we passed in a default value, set it as the Field's `data`-value
             if (array_key_exists($name, $data)) {
-                if(is_iterable($data[$name])){
+                if (is_iterable($data[$name])) {
                     $field['options'] = array_merge($field['options'], $data[$name]['options']);
                 } else {
                     $field['options']['data'] = $data[$name];


### PR DESCRIPTION
Add ability to decide whether to cache the choices of type contenttype when large data set is involved. This is optional and the cache lifetime can be set as well. 
NB: These choices are being fetched from the database and large records cause the website to slow down until the fetch is done.