### PR TITLE
Fix `RepeatedType` field

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -184,6 +184,11 @@ class FormBuilder
         $type = FieldType::get($field);
         $options = FieldOptions::get($name, $field, $config);
 
+        // This part is needed for the `repeated` type
+        if (isset($options['type'])) {
+            $options['type'] = FieldType::get($options);
+        }
+
         $formBuilder->add($name, $type, $options);
     }
 


### PR DESCRIPTION
This PR fixes a 'Could not load type "xyz": class does not exist.' error for repeated fields. See below:
```
password:
    type: 'repeated'
    options:
        type: 'password' # <-- This part needs to be converted to 'Symfony\Component\Form\Extension\Core\Type\PasswordType'
        required: true
        first_options:
            label: 'Password'
        second_options:
            label: 'Repeat Password'
```
See https://symfony.com/doc/5.4/reference/forms/types/repeated.html