### PR TITLE
Get file uploads as e-mail attachments.

### DIFF
--- a/src/Factory/EmailFactory.php
+++ b/src/Factory/EmailFactory.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Bolt\BoltForms\Factory;
 
 use Bolt\Common\Str;
-use File;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\Address;
 use Tightenco\Collect\Support\Collection;
 
@@ -67,10 +67,11 @@ class EmailFactory
             $email->replyTo($this->getReplyTo());
         }
 
-        foreach ($attachments as $name => $attachment) {
-            /** @var File $attachment */
-            foreach ($attachment as $file) {
-                $email->attachFromPath($file, $name . '.' . pathinfo($file, PATHINFO_EXTENSION));
+        foreach ($attachments as $attachment) {
+            try {
+                $email->attach($attachment["content"], $attachment["filename"], $attachment["mimetype"]);
+            } catch (\Exception $e) {
+                // Re-submit of the form will have an "empty" file, for example.
             }
         }
 


### PR DESCRIPTION
This does currently not use the sanitized filenames nor the stored files. It simply grabs the blobs from the Symfony form.

To solve this more neatly, the FileUploadHandler should somehow have a way of passing along its resulting array of file data back to the event. Not sure if that's actually a best practice.

But hey, it works.

Solves a part of #82 .