### PR TITLE
Check if array is empty when no image is uploaded

### DIFF
--- a/src/EventSubscriber/ContentTypePersister.php
+++ b/src/EventSubscriber/ContentTypePersister.php
@@ -88,7 +88,8 @@ class ContentTypePersister extends AbstractPersistSubscriber implements EventSub
 
             if (is_array($value)) {
                 $value = implode(', ', array_map(function ($entry) {
-                    return $entry[0];
+                    // check if $entry is an array and not empty
+                    return (is_array($entry) && count($entry) > 0) ? $entry[0] : '';
                 }, $value));
             }
             


### PR DESCRIPTION
On submitting form, when no image is attached, it resulted in "Warning: Undefined array key 0" error.
This adjustment should prevent the error.