### PR TITLE
fix: DirectoryNotFoundException on Windows

### DIFF
--- a/src/BoltFormsConfig.php
+++ b/src/BoltFormsConfig.php
@@ -71,6 +71,10 @@ class BoltFormsConfig
     {
         $configPath = explode('.yaml', $this->getExtension()->getConfigFilenames()['main'])[0] . DIRECTORY_SEPARATOR;
 
+        if (!is_dir($configPath)) {
+            return [];
+        }
+
         $finder = new Finder();
 
         $finder->files()->in($configPath)->name('*.yaml');


### PR DESCRIPTION
This fix an error of unable to find config file in windows.

```
Twig\Error\RuntimeError:
An exception has been thrown during the rendering of a template
("The "C:/laragon/www/boltprojectname/config/extensions\bolt-boltforms\" directory does not exist.").
```
```
Symfony\Component\Finder\Exception\DirectoryNotFoundException:
The "C:/laragon/www/boltprojectname/config/extensions\bolt-boltforms\" directory does not exist.
```